### PR TITLE
Adding dns to lb

### DIFF
--- a/api/v1alpha3/hcloudcluster_types.go
+++ b/api/v1alpha3/hcloudcluster_types.go
@@ -51,6 +51,8 @@ type HcloudClusterSpec struct {
 	// +kubebuilder:validation:MaxItems=10
 	ControlPlaneLoadBalancers []HcloudLoadBalancerSpec `json:"controlPlaneLoadbalancer,omitempty"`
 
+	KubeAPIServerDomain *string `json:"kubeAPIServerDomain,omitempty"`
+
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
@@ -103,14 +105,15 @@ type HcloudLoadBalancerSpec struct {
 	ListenPort *int                            `json:"listenPort,omitempty"`
 }
 type HcloudLoadBalancerStatus struct {
-	ID        int                             `json:"id,omitempty"`
-	Name      string                          `json:"name,omitempty"`
-	Type      string                          `json:"type,omitempty"`
-	IPv4      string                          `json:"ipv4,omitempty"`
-	IPv6      string                          `json:"ipv6,omitempty"`
-	Labels    map[string]string               `json:"-"`
-	Algorithm HcloudLoadBalancerAlgorithmType `json:"algorithm,omitempty"`
-	Targets   []int                           `json:"-"`
+	ID         int                             `json:"id,omitempty"`
+	Name       string                          `json:"name,omitempty"`
+	Type       string                          `json:"type,omitempty"`
+	IPv4       string                          `json:"ipv4,omitempty"`
+	IPv6       string                          `json:"ipv6,omitempty"`
+	ListenPort int                             `json:"listenPort,omitempty"`
+	Labels     map[string]string               `json:"-"`
+	Algorithm  HcloudLoadBalancerAlgorithmType `json:"algorithm,omitempty"`
+	Targets    []int                           `json:"-"`
 }
 
 type HcloudClusterStatusManifests struct {
@@ -124,6 +127,7 @@ type HcloudClusterStatus struct {
 	NetworkZone               HcloudNetworkZone          `json:"networkZone,omitempty"`
 	ControlPlaneLoadBalancers []HcloudLoadBalancerStatus `json:"controlPlaneLoadBalancers,omitempty"`
 
+	KubeAPIServerDomain string `json:"kubeAPIServerDomain,omitempty"`
 	// +optional
 	Network *HcloudNetworkStatus `json:"network,omitempty"`
 

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -107,6 +107,11 @@ func (in *HcloudClusterSpec) DeepCopyInto(out *HcloudClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.KubeAPIServerDomain != nil {
+		in, out := &in.KubeAPIServerDomain, &out.KubeAPIServerDomain
+		*out = new(string)
+		**out = **in
+	}
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if in.Network != nil {
 		in, out := &in.Network, &out.Network

--- a/config/crd/bases/cluster-api-provider-hcloud.capihc.com_hcloudclusters.yaml
+++ b/config/crd/bases/cluster-api-provider-hcloud.capihc.com_hcloudclusters.yaml
@@ -77,6 +77,8 @@ spec:
                 maxItems: 10
                 minItems: 1
                 type: array
+              kubeAPIServerDomain:
+                type: string
               locations:
                 items:
                   type: string
@@ -142,6 +144,8 @@ spec:
                       type: string
                     ipv6:
                       type: string
+                    listenPort:
+                      type: integer
                     name:
                       type: string
                     type:
@@ -168,6 +172,8 @@ spec:
                 type: string
               failureReason:
                 description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              kubeAPIServerDomain:
                 type: string
               locations:
                 items:

--- a/controllers/hcloudcluster_controller.go
+++ b/controllers/hcloudcluster_controller.go
@@ -201,7 +201,8 @@ func (r *HcloudClusterReconciler) reconcileNormal(clusterScope *scope.ClusterSco
 	if hcloudCluster.Spec.KubeAPIServerDomain != nil {
 		hcloudCluster.Status.KubeAPIServerDomain = *hcloudCluster.Spec.KubeAPIServerDomain
 	}
-
+	fmt.Println(hcloudCluster.Status.KubeAPIServerDomain)
+	fmt.Printf("in Cluster controller: %s", hcloudCluster.Status.KubeAPIServerDomain)
 	// reconcile the load balancers
 	if err := loadbalancer.NewService(clusterScope).Reconcile(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile load balancers for HcloudCluster %s/%s", hcloudCluster.Namespace, hcloudCluster.Name)

--- a/controllers/hcloudcluster_controller.go
+++ b/controllers/hcloudcluster_controller.go
@@ -201,8 +201,7 @@ func (r *HcloudClusterReconciler) reconcileNormal(clusterScope *scope.ClusterSco
 	if hcloudCluster.Spec.KubeAPIServerDomain != nil {
 		hcloudCluster.Status.KubeAPIServerDomain = *hcloudCluster.Spec.KubeAPIServerDomain
 	}
-	fmt.Println(hcloudCluster.Status.KubeAPIServerDomain)
-	fmt.Printf("in Cluster controller: %s", hcloudCluster.Status.KubeAPIServerDomain)
+
 	// reconcile the load balancers
 	if err := loadbalancer.NewService(clusterScope).Reconcile(ctx); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile load balancers for HcloudCluster %s/%s", hcloudCluster.Namespace, hcloudCluster.Name)

--- a/demo/demo-cluster.yaml
+++ b/demo/demo-cluster.yaml
@@ -25,6 +25,7 @@ metadata:
   name: cluster-dev
   namespace: default
 spec:
+  kubeAPIServerDomain: cluster.syself.net
   controlPlaneLoadbalancer:
   - type: lb11
     algorithm: round_robin

--- a/demo/demo-cluster.yaml
+++ b/demo/demo-cluster.yaml
@@ -25,7 +25,7 @@ metadata:
   name: cluster-dev
   namespace: default
 spec:
-  kubeAPIServerDomain: cluster.syself.net
+  # kubeAPIServerDomain: example.com
   controlPlaneLoadbalancer:
   - type: lb11
     algorithm: round_robin

--- a/demo/demo-cluster.yaml
+++ b/demo/demo-cluster.yaml
@@ -25,7 +25,7 @@ metadata:
   name: cluster-dev
   namespace: default
 spec:
-  kubeAPIServerDomain: cluster.syself.net
+  kubeAPIServerDomain: https://cluster.syself.net
   controlPlaneLoadbalancer:
   - type: lb11
     algorithm: round_robin

--- a/demo/demo-cluster.yaml
+++ b/demo/demo-cluster.yaml
@@ -25,7 +25,7 @@ metadata:
   name: cluster-dev
   namespace: default
 spec:
-  kubeAPIServerDomain: https://cluster.syself.net
+  kubeAPIServerDomain: cluster.syself.net
   controlPlaneLoadbalancer:
   - type: lb11
     algorithm: round_robin

--- a/manifests/config-extvar.jsonnet
+++ b/manifests/config-extvar.jsonnet
@@ -4,7 +4,8 @@ local utils = import 'utils.libsonnet';
 local myConfig = {
   hcloudToken: std.extVar('hcloud-token'),
   hcloudNetwork: std.extVar('hcloud-network'),
-  hcloudLoadBalancerIPv4s: std.split(std.extVar('hcloud-loadbalancer'), ','),
+  kubeAPIServerIPv4: std.extVar('kube-apiserver-ip'),
+  kubeAPIServerDomain: std.extVar('kube-apiserver-domain'),
   podsCIDRBlock: std.extVar('pod-cidr-block'),
   manifests: std.split(std.extVar('manifests'), ','),
 };

--- a/manifests/config.jsonnet
+++ b/manifests/config.jsonnet
@@ -82,10 +82,10 @@ local specs(ip, domain) =
         targetPort: 6443,
       },
     ],
-    type: 'LoadBalancer',
+    type: 'ExternalName',
     loadBalancerIP: ip,
     externalTrafficPolicy: 'Local',
-    hostName: domain,
+    externalName: domain,
     externalIPs: [
       ip,
     ],

--- a/manifests/config.jsonnet
+++ b/manifests/config.jsonnet
@@ -96,7 +96,7 @@ local newControlPlaneService(ip, domain) = {
   apiVersion: 'v1',
   kind: 'Service',
   metadata: {
-    name: 'kube-apiserver-%d' % pos,
+    name: 'kube-apiserver,
     namespace: 'kube-system',
   },
   spec: specs(ip, domain),

--- a/manifests/config.jsonnet
+++ b/manifests/config.jsonnet
@@ -117,7 +117,7 @@ local addons = {
     },
   },
 
-  controlPlaneServices: newControlPlaneService($._config.hcloudLoadBalancerIPv4, $._config.kubeAPIServerDomain),
+  controlPlaneServices: newControlPlaneService($._config.kubeAPIServerIPv4, $._config.kubeAPIServerDomain),
 
   workarounds: {
     // This fixes a problem join v1.18 node to a v1.17 control plane

--- a/manifests/config.jsonnet
+++ b/manifests/config.jsonnet
@@ -51,14 +51,8 @@ local defaultConfig = {
   hcloudLoadBalancerIPv4s: ['1.1.1.1', '2.2.2.2'],
 };
 
-local newControlPlaneService(pos, ip) = {
-  apiVersion: 'v1',
-  kind: 'Service',
-  metadata: {
-    name: 'kube-apiserver-%d' % pos,
-    namespace: 'kube-system',
-  },
-  spec: {
+local specs(ip, domain) =
+  if (domain == "") then {
     selector: {
       component: 'kube-apiserver',
       tier: 'control-plane',
@@ -76,7 +70,36 @@ local newControlPlaneService(pos, ip) = {
     externalIPs: [
       ip,
     ],
+  } else {
+    selector: {
+      component: 'kube-apiserver',
+      tier: 'control-plane',
+    },
+    ports: [
+      {
+        protocol: 'TCP',
+        port: 6443,
+        targetPort: 6443,
+      },
+    ],
+    type: 'LoadBalancer',
+    loadBalancerIP: ip,
+    externalTrafficPolicy: 'Local',
+    hostName: domain,
+    externalIPs: [
+      ip,
+    ],
+};
+
+
+local newControlPlaneService(ip, domain) = {
+  apiVersion: 'v1',
+  kind: 'Service',
+  metadata: {
+    name: 'kube-apiserver-%d' % pos,
+    namespace: 'kube-system',
   },
+  spec: specs(ip, domain),
 };
 
 local addons = {
@@ -94,7 +117,7 @@ local addons = {
     },
   },
 
-  controlPlaneServices: std.mapWithIndex(newControlPlaneService, $._config.hcloudLoadBalancerIPv4s),
+  controlPlaneServices: newControlPlaneService($._config.hcloudLoadBalancerIPv4, $._config.kubeAPIServerDomain),
 
   workarounds: {
     // This fixes a problem join v1.18 node to a v1.17 control plane

--- a/manifests/config.jsonnet
+++ b/manifests/config.jsonnet
@@ -82,7 +82,7 @@ local specs(ip, domain) =
         targetPort: 6443,
       },
     ],
-    type: 'ExternalName',
+    type: 'LoadBalancer',
     loadBalancerIP: ip,
     externalTrafficPolicy: 'Local',
     externalName: domain,

--- a/manifests/config.jsonnet
+++ b/manifests/config.jsonnet
@@ -48,7 +48,7 @@ local defaultConfig = {
   podsCIDRBlock: '192.168.0.0/16',
   hcloudToken: 'xx',
   hcloudNetwork: 'yy',
-  hcloudLoadBalancerIPv4s: ['1.1.1.1', '2.2.2.2'],
+  hcloudLoadBalancerIPv4: '1.1.1.1',
 };
 
 local specs(ip, domain) =
@@ -96,7 +96,7 @@ local newControlPlaneService(ip, domain) = {
   apiVersion: 'v1',
   kind: 'Service',
   metadata: {
-    name: 'kube-apiserver,
+    name: 'kube-apiserver',
     namespace: 'kube-system',
   },
   spec: specs(ip, domain),

--- a/pkg/cloud/resources/loadbalancer/loadbalancer.go
+++ b/pkg/cloud/resources/loadbalancer/loadbalancer.go
@@ -38,7 +38,7 @@ func (s intSlice) contains(e int) bool {
 }
 
 // gets the information of the Hetzner load balancer object and returns it in our status object
-func apiToStatus(lb *hcloud.LoadBalancer) (*infrav1.HcloudLoadBalancerStatus, error) {
+func (s *Service) apiToStatus(lb *hcloud.LoadBalancer) (*infrav1.HcloudLoadBalancerStatus, error) {
 
 	ipv4 := lb.PublicNet.IPv4.IP.String()
 	ipv6 := lb.PublicNet.IPv6.IP.String()
@@ -60,14 +60,15 @@ func apiToStatus(lb *hcloud.LoadBalancer) (*infrav1.HcloudLoadBalancerStatus, er
 	}
 
 	status := &infrav1.HcloudLoadBalancerStatus{
-		ID:        lb.ID,
-		Name:      lb.Name,
-		Type:      lb.LoadBalancerType.Name,
-		IPv4:      ipv4,
-		IPv6:      ipv6,
-		Labels:    lb.Labels,
-		Algorithm: algType,
-		Targets:   targetIDs,
+		ID:         lb.ID,
+		Name:       lb.Name,
+		Type:       lb.LoadBalancerType.Name,
+		IPv4:       ipv4,
+		IPv6:       ipv6,
+		Labels:     lb.Labels,
+		Algorithm:  algType,
+		Targets:    targetIDs,
+		ListenPort: lb.Services[0].ListenPort,
 	}
 	return status, nil
 }
@@ -209,7 +210,7 @@ func (s *Service) createLoadBalancer(ctx context.Context, spec infrav1.HcloudLoa
 		return nil, fmt.Errorf("error creating load balancer: %s", err)
 	}
 
-	status, err := apiToStatus(lb.LoadBalancer)
+	status, err := s.apiToStatus(lb.LoadBalancer)
 	if err != nil {
 		return nil, fmt.Errorf("error converting load balancer: %s", err)
 	}
@@ -350,7 +351,7 @@ func (s *Service) actualStatus(ctx context.Context) ([]infrav1.HcloudLoadBalance
 			continue
 		}
 
-		lbStatus, err := apiToStatus(lb)
+		lbStatus, err := s.apiToStatus(lb)
 		if err != nil {
 			return nil, fmt.Errorf("error converting LoadBalancer API to status: %w", err)
 		}

--- a/pkg/cloud/resources/server/server.go
+++ b/pkg/cloud/resources/server/server.go
@@ -256,11 +256,13 @@ func (s *Service) Reconcile(ctx context.Context) (_ *ctrl.Result, err error) {
 				extraNames := []string{"127.0.0.1", "localhost"}
 				if s.scope.HcloudCluster.Status.KubeAPIServerDomain != "" {
 					extraNames = append(extraNames, s.scope.HcloudCluster.Status.KubeAPIServerDomain)
+				} else {
+					for _, lb := range s.scope.HcloudCluster.Status.ControlPlaneLoadBalancers {
+						extraNames = append(extraNames, lb.IPv4)
+						extraNames = append(extraNames, lb.IPv6)
+					}
 				}
-				for _, lb := range s.scope.HcloudCluster.Status.ControlPlaneLoadBalancers {
-					extraNames = append(extraNames, lb.IPv4)
-					extraNames = append(extraNames, lb.IPv6)
-				}
+
 				for _, name := range extraNames {
 					if !stringSliceContains(c.APIServer.CertSANs, name) {
 						c.APIServer.CertSANs = append(

--- a/pkg/cloud/resources/server/server.go
+++ b/pkg/cloud/resources/server/server.go
@@ -254,6 +254,9 @@ func (s *Service) Reconcile(ctx context.Context) (_ *ctrl.Result, err error) {
 
 				// configure APIserver serving certificate
 				extraNames := []string{"127.0.0.1", "localhost"}
+				if s.scope.HcloudCluster.Status.KubeAPIServerDomain != "" {
+					extraNames = append(extraNames, s.scope.HcloudCluster.Status.KubeAPIServerDomain)
+				}
 				for _, lb := range s.scope.HcloudCluster.Status.ControlPlaneLoadBalancers {
 					extraNames = append(extraNames, lb.IPv4)
 					extraNames = append(extraNames, lb.IPv6)

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -207,7 +207,7 @@ func (s *ClusterScope) manifestParameters() (*parameters.ManifestParameters, err
 	var p parameters.ManifestParameters
 
 	p.KubeAPIServerIPv4 = &s.HcloudCluster.Status.ControlPlaneLoadBalancers[0].IPv4
-	fmt.Printf("in cluster.go: IPv4: %s", *p.KubeAPIServerIPv4)
+
 	p.KubeAPIServerDomain = &s.HcloudCluster.Status.KubeAPIServerDomain
 
 	p.HcloudToken = &s.hcloudToken

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -207,7 +207,7 @@ func (s *ClusterScope) manifestParameters() (*parameters.ManifestParameters, err
 	var p parameters.ManifestParameters
 
 	p.KubeAPIServerIPv4 = &s.HcloudCluster.Status.ControlPlaneLoadBalancers[0].IPv4
-
+	fmt.Printf("in cluster.go: IPv4: %s", *p.KubeAPIServerIPv4)
 	p.KubeAPIServerDomain = &s.HcloudCluster.Status.KubeAPIServerDomain
 
 	p.HcloudToken = &s.hcloudToken

--- a/pkg/cloud/scope/cluster.go
+++ b/pkg/cloud/scope/cluster.go
@@ -206,12 +206,9 @@ func (s *ClusterScope) ClientConfigWithAPIEndpoint(endpoint clusterv1.APIEndpoin
 func (s *ClusterScope) manifestParameters() (*parameters.ManifestParameters, error) {
 	var p parameters.ManifestParameters
 
-	for _, loadBalancer := range s.HcloudCluster.Status.ControlPlaneLoadBalancers {
-		p.HcloudLoadBalancerIPv4s = append(
-			p.HcloudLoadBalancerIPv4s,
-			loadBalancer.IPv4,
-		)
-	}
+	p.KubeAPIServerIPv4 = &s.HcloudCluster.Status.ControlPlaneLoadBalancers[0].IPv4
+
+	p.KubeAPIServerDomain = &s.HcloudCluster.Status.KubeAPIServerDomain
 
 	p.HcloudToken = &s.hcloudToken
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -20,6 +20,7 @@ import (
 func sampleParameters() *parameters.ManifestParameters {
 	hcloudNetwork := intstr.FromString("cluster-dev")
 	hcloudToken := "my-token"
+	kubeAPIServerDomain := ""
 	manifests := []string{"hcloudCSI", "metricsServer"}
 	_, podCIDRBlock, err := net.ParseCIDR("192.168.0.0/17")
 	if err != nil {
@@ -27,10 +28,11 @@ func sampleParameters() *parameters.ManifestParameters {
 	}
 
 	return &parameters.ManifestParameters{
-		HcloudToken:   &hcloudToken,
-		HcloudNetwork: &hcloudNetwork,
-		PodCIDRBlock:  podCIDRBlock,
-		Manifests:     manifests,
+		HcloudToken:         &hcloudToken,
+		HcloudNetwork:       &hcloudNetwork,
+		PodCIDRBlock:        podCIDRBlock,
+		Manifests:           manifests,
+		KubeAPIServerDomain: &kubeAPIServerDomain,
 	}
 }
 

--- a/pkg/manifests/parameters/parameters.go
+++ b/pkg/manifests/parameters/parameters.go
@@ -8,17 +8,24 @@ import (
 )
 
 type ManifestParameters struct {
-	HcloudToken             *string
-	HcloudNetwork           *intstr.IntOrString
-	HcloudLoadBalancerIPv4s []string
-	PodCIDRBlock            *net.IPNet
-	Manifests               []string
+	HcloudToken         *string
+	HcloudNetwork       *intstr.IntOrString
+	KubeAPIServerIPv4   *string
+	KubeAPIServerDomain *string
+	PodCIDRBlock        *net.IPNet
+	Manifests           []string
 }
 
 func (m *ManifestParameters) ExtVar() map[string]string {
 	extVar := make(map[string]string)
 
-	extVar["hcloud-loadbalancer"] = strings.Join(m.HcloudLoadBalancerIPv4s, ",")
+	if key, val := "kube-apiserver-ip", m.KubeAPIServerIPv4; val != nil {
+		extVar[key] = *val
+	}
+
+	if key, val := "kube-apiserver-domain", m.KubeAPIServerDomain; val != nil {
+		extVar[key] = *val
+	}
 
 	extVar["manifests"] = strings.Join(m.Manifests, ",")
 

--- a/pkg/manifests/parameters/parameters.go
+++ b/pkg/manifests/parameters/parameters.go
@@ -1,6 +1,7 @@
 package parameters
 
 import (
+	"fmt"
 	"net"
 	"strings"
 
@@ -21,10 +22,16 @@ func (m *ManifestParameters) ExtVar() map[string]string {
 
 	if key, val := "kube-apiserver-ip", m.KubeAPIServerIPv4; val != nil {
 		extVar[key] = *val
+	} else {
+		extVar[key] = ""
 	}
+
+	fmt.Printf("Parameters.go: %s", *m.KubeAPIServerDomain)
 
 	if key, val := "kube-apiserver-domain", m.KubeAPIServerDomain; val != nil {
 		extVar[key] = *val
+	} else {
+		extVar[key] = ""
 	}
 
 	extVar["manifests"] = strings.Join(m.Manifests, ",")

--- a/pkg/manifests/parameters/parameters.go
+++ b/pkg/manifests/parameters/parameters.go
@@ -1,7 +1,6 @@
 package parameters
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -25,8 +24,6 @@ func (m *ManifestParameters) ExtVar() map[string]string {
 	} else {
 		extVar[key] = ""
 	}
-
-	fmt.Printf("Parameters.go: %s", *m.KubeAPIServerDomain)
 
 	if key, val := "kube-apiserver-domain", m.KubeAPIServerDomain; val != nil {
 		extVar[key] = *val


### PR DESCRIPTION
This PR adds the ability to use a domain name for the kubeapiserver.
