### PR TITLE
:bug: Fix en_US.UTF-9 not installed error

### DIFF
--- a/baremetal/bm-centos-8_k8s-v1.19.0-runc/scripts/configure_base.sh
+++ b/baremetal/bm-centos-8_k8s-v1.19.0-runc/scripts/configure_base.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 # Set locale
 localectl set-locale LANG=en_US.UTF-8 
-localectl set-locale LANGUAGE=en_US.UTF-9
 
 # Ensure that the correct repos are installed
 cat > /etc/yum.repos.d/CentOS-Base.repo <<EOF
@@ -89,4 +88,3 @@ Options=rw,nosuid,nodev,noexec,relatime,mode=700
 WantedBy=multi-user.target
 EOF
 systemctl enable sys-fs-bpf.mount
-

--- a/packer/centos-8_k8s-v1.19.0-privnet/scripts/configure_base.sh
+++ b/packer/centos-8_k8s-v1.19.0-privnet/scripts/configure_base.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 # Set locale
 localectl set-locale LANG=en_US.UTF-8 
-localectl set-locale LANGUAGE=en_US.UTF-9
 
 # Ensure that the correct repos are installed
 cat > /etc/yum.repos.d/CentOS-Base.repo <<EOF
@@ -116,5 +115,3 @@ WantedBy=multi-user.target
 EOF
 
 systemctl enable disable-public-interface.service
-
-

--- a/packer/centos-8_k8s-v1.19.0/scripts/configure_base.sh
+++ b/packer/centos-8_k8s-v1.19.0/scripts/configure_base.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 # Set locale
 localectl set-locale LANG=en_US.UTF-8 
-localectl set-locale LANGUAGE=en_US.UTF-9
 
 # Ensure that the correct repos are installed
 cat > /etc/yum.repos.d/CentOS-Base.repo <<EOF
@@ -96,4 +95,3 @@ systemctl enable sys-fs-bpf.mount
 # Set SELinux in enforcing mode (effectively disabling it)
 setenforce 1
 sed -i 's/^SELINUX=permissive\$/SELINUX=enforcing/' /etc/selinux/config
-

--- a/packer/centos-8_k8s-v1.19.3/scripts/configure_base.sh
+++ b/packer/centos-8_k8s-v1.19.3/scripts/configure_base.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 # Set locale
 localectl set-locale LANG=en_US.UTF-8 
-localectl set-locale LANGUAGE=en_US.UTF-9
 
 # Ensure that the correct repos are installed
 cat > /etc/yum.repos.d/CentOS-Base.repo <<EOF
@@ -96,4 +95,3 @@ systemctl enable sys-fs-bpf.mount
 # Set SELinux in enforcing mode (effectively disabling it)
 setenforce 1
 sed -i 's/^SELINUX=permissive\$/SELINUX=enforcing/' /etc/selinux/config
-


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Packer is failing on the error 'Failed to issue method call: Locale en_US.UTF-9 not installed, refusing.' with CentOS 8. Removing the setting of the LANGUAGE locale resolves this.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
